### PR TITLE
Fixes to get clang to compile, and note about directory name requirement.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -1,3 +1,5 @@
+Note that the top level directory must be named 'jay' for the Makefiles to work.
+
 installation instructions
 
 (0) if you work with SSCLI, make sure the path to this directory (after resolving any symbolic links) does not contain blanks -- blanks seem to confuse at least SSCLI on MacOS X 10.2.2.
@@ -22,7 +24,7 @@ If a suitable SSCLI is installed, it will also test in cs/{arith,recover}/.
 
 (4) copy some of {java,cs}/skeleton.* to a convenient location.
 
-(5) you might want to install a skript somewhere with something like
+(5) you might want to install a script somewhere with something like
 
 #!/bin/sh
 exec [path]/jay < [path]/[skeleton] "$@"

--- a/src/error.c
+++ b/src/error.c
@@ -80,7 +80,7 @@ char *st_cptr;
 {
     register char *s;
 
-    if (st_line == 0) return;
+    if (st_line == 0) return NULL;
     for (s = st_line; *s != '\n'; ++s)
     {
 	if (isprint(*s) || *s == '\t')

--- a/src/main.c
+++ b/src/main.c
@@ -135,7 +135,7 @@ usage()
 }
 
 
-getargs(argc, argv)
+void getargs(argc, argv)
 int argc;
 char *argv[];
 {

--- a/src/makefile
+++ b/src/makefile
@@ -6,7 +6,7 @@
 #   make CC=c89 will create jay.exe with Visual C++.
 
 CC	= `if [ -n "$$COMSPEC" ]; then echo gcc; else echo cc; fi`
-CFLAGS	= -s # -g
+CFLAGS	= -s --std=c89 # -g
 
 c	= closure.c error.c lalr.c lr0.c main.c mkpar.c output.c reader.c \
 	  symtab.c verbose.c warshall.c

--- a/src/output.c
+++ b/src/output.c
@@ -343,7 +343,7 @@ int default_state;
 	if (to_state[i] != default_state)
 	    ++count;
     }
-    if (count == 0) return;
+    if (count == 0) return 0;
 
     symno = symbol_value[symbol] + 2*nstates;
 
@@ -920,13 +920,13 @@ output_yyRule_strings () {
   }
 }
 
-output_trailing_text()
+int output_trailing_text()
 {
     register int c, last;
     register FILE *in;
 
     if (line == 0)
-	return;
+	return 0;
 
     in = input_file;
     c = *cptr;
@@ -934,7 +934,7 @@ output_trailing_text()
     {
 	++lineno;
 	if ((c = getc(in)) == EOF)
-	    return;
+	    return 0;
         ++outline;
 	printf(line_format, lineno, input_file_name);
 	if (c == '\n')
@@ -969,7 +969,7 @@ output_trailing_text()
 }
 
 
-output_semantic_actions()
+int output_semantic_actions()
 {
     register int c, last;
 
@@ -979,7 +979,7 @@ output_semantic_actions()
 	open_error(action_file_name);
 
     if ((c = getc(action_file)) == EOF)
-	return;
+	return 0;
 
     last = c;
     if (c == '\n')

--- a/src/reader.c
+++ b/src/reader.c
@@ -100,7 +100,7 @@ get_line()
 	if (line) { FREE(line); line = 0; }
 	cptr = 0;
 	saw_eof = 1;
-	return;
+	return 0;
     }
 
     if (line == 0 || linesize != (LINESIZE + 1))
@@ -116,7 +116,7 @@ get_line()
     for (;;)
     {
 	line[i]  =  c;
-	if (c == '\n') { cptr = line; return; }
+	if (c == '\n') { cptr = line; return 0; }
 	if (++i >= linesize)
 	{
 	    linesize += LINESIZE;
@@ -129,7 +129,7 @@ get_line()
 	    line[i] = '\n';
 	    saw_eof = 1;
 	    cptr = line;
-	    return;
+	    return 0;
 	}
     }
 }
@@ -168,7 +168,7 @@ skip_comment()
 	{
 	    cptr = s + 2;
 	    FREE(st_line);
-	    return;
+	    return 0;
 	}
 	if (*s == '\n')
 	{
@@ -415,7 +415,7 @@ loop:
 	    if (need_newline) putc('\n', f);
 	    ++cptr;
 	    FREE(t_line);
-	    return;
+	    return 0;
 	}
 	/* fall through */
 
@@ -711,7 +711,7 @@ int assoc;
 	else if (c == '\'' || c == '"')
 	    bp = get_literal();
 	else
-	    return;
+	    return 0;
 
 	if (bp == goal) tokenized_start(bp->name);
 	bp->class = TERM;
@@ -766,7 +766,7 @@ declare_types()
 	else if (c == '\'' || c == '"')
 	    bp = get_literal();
 	else
-	    return;
+	    return 0;
 
 	if (bp->tag && tag != bp->tag)
 	    retyped_warning(bp->name);
@@ -809,7 +809,7 @@ read_declarations()
 	switch (k = keyword())
 	{
 	case MARK:
-	    return;
+	    return 0;
 
 	case TEXT:
 	    copy_text(prolog_file);
@@ -1016,7 +1016,7 @@ add_symbol()
 	end_rule();
 	start_rule(bp, s_lineno);
 	++cptr;
-	return;
+	return 0;
     }
 
     if (last_was_action)
@@ -1163,7 +1163,7 @@ loop:
     case ';':
 	if (depth > 0) goto loop;
 	fprintf(f, "\nbreak;\n");
-	return;
+	return 0;
 
     case '{':
 	++depth;
@@ -1172,7 +1172,7 @@ loop:
     case '}':
 	if (--depth > 0) goto loop;
 	fprintf(f, "\n  break;\n");
-	return;
+	return 0;
 
     case '\'':
     case '"':
@@ -1338,7 +1338,7 @@ free_tags()
 {
     register int i;
 
-    if (tag_table == 0) return;
+    if (tag_table == 0) return 0;
 
     for (i = 0; i < ntags; ++i)
     {
@@ -1581,7 +1581,7 @@ print_grammar()
     int spacing;
     register FILE *f = verbose_file;
 
-    if (!vflag) return;
+    if (!vflag) return 0;
 
     k = 1;
     for (i = 2; i < nrules; ++i)

--- a/src/verbose.c
+++ b/src/verbose.c
@@ -46,7 +46,7 @@ verbose()
 {
     register int i;
 
-    if (!vflag) return;
+    if (!vflag) return 0;
 
     null_rules = (short *) MALLOC(nrules*sizeof(short));
     if (null_rules == 0) no_space();


### PR DESCRIPTION
CLang wouldn't compile this without these fixes, even with --std=c89. Hmmm perhaps I should have tried -ansi... never mind - this fixes it.

Also added a note that the top level directory must be called jay. Spent too long figuring that out.
